### PR TITLE
Replace derive with manual Deserialize implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,6 @@ dependencies = [
  "getset",
  "serde",
  "serde_json",
- "serde_repr",
 ]
 
 [[package]]
@@ -107,17 +106,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT/Apache-2.0"
 [dependencies]
 getset = "0.1"
 serde = { version = "1", features = ["derive"] }
-serde_repr = "0.1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -1,4 +1,4 @@
-#[derive(serde_repr::Deserialize_repr, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Priority {
     // system is unusable
@@ -24,6 +24,29 @@ pub enum Priority {
 
     // debug-level message
     DEBUG = 7,
+
+    // If deserializing to another variant failed
+    Unknown(String),
+}
+
+impl<'de> serde::Deserialize<'de> for Priority {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_ref() {
+            "0" => Priority::EMERG,
+            "1" => Priority::ALERT,
+            "2" => Priority::CRIT,
+            "3" => Priority::ERR,
+            "4" => Priority::WARNING,
+            "5" => Priority::NOTICE,
+            "6" => Priority::INFO,
+            "7" => Priority::DEBUG,
+            _ => Priority::Unknown(s),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -37,56 +60,56 @@ mod tests {
 
     #[test]
     fn test_deser_emerg() {
-        let s = r#"{"p":0}"#;
+        let s = r#"{"p":"0"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::EMERG);
     }
 
     #[test]
     fn test_deser_alert() {
-        let s = r#"{"p":1}"#;
+        let s = r#"{"p":"1"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::ALERT);
     }
 
     #[test]
     fn test_deser_crit() {
-        let s = r#"{"p":2}"#;
+        let s = r#"{"p":"2"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::CRIT);
     }
 
     #[test]
     fn test_deser_err() {
-        let s = r#"{"p":3}"#;
+        let s = r#"{"p":"3"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::ERR);
     }
 
     #[test]
     fn test_deser_warning() {
-        let s = r#"{"p":4}"#;
+        let s = r#"{"p":"4"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::WARNING);
     }
 
     #[test]
     fn test_deser_notice() {
-        let s = r#"{"p":5}"#;
+        let s = r#"{"p":"5"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::NOTICE);
     }
 
     #[test]
     fn test_deser_info() {
-        let s = r#"{"p":6}"#;
+        let s = r#"{"p":"6"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::INFO);
     }
 
     #[test]
     fn test_deser_debug() {
-        let s = r#"{"p":7}"#;
+        let s = r#"{"p":"7"}"#;
         let o: Obj = serde_json::from_str(s).unwrap();
         assert_eq!(o.p, Priority::DEBUG);
     }


### PR DESCRIPTION
#5 did not fix the issue, because the journal json uses a string for representing priority numbers.

This PR fixes this by hand-implementing the `Deserialize` trait for `Priority`.